### PR TITLE
Fix GitHub Actions CI pipeline errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         macos: [macos-latest]
-        ios: ["26.0"]
+        ios: ["26.0.1"]
         xcode: ["26"]
     runs-on: ${{ matrix.macos }}
     steps:
@@ -36,7 +36,7 @@ jobs:
       fail-fast: false
       matrix:
         macos: [macos-latest]
-        ios: ["26.0"]
+        ios: ["26.0.1"]
         xcode: ["26"]
     runs-on: ${{ matrix.macos }}
     steps:


### PR DESCRIPTION
The CI was failing because it was trying to use iOS 26.0 with iPhone 17 Pro, but the available simulators only have iOS 26.0.1 with iPhone 17 Pro.

Error was:
xcodebuild: error: Unable to find a device matching the provided destination specifier: { platform:iOS Simulator, OS:26.0, name:iPhone 17 Pro }

Fixed by updating the iOS version in the matrix from "26.0" to "26.0.1".