### PR TITLE
test(ui): drop fixed sleeps and route assertions through page objects

### DIFF
--- a/FARTUITests/Pages/BasePage.swift
+++ b/FARTUITests/Pages/BasePage.swift
@@ -107,9 +107,10 @@ class BasePage {
     // Tap picker and find option — retry once if menu doesn't open
     for attempt in 0..<2 {
       if attempt > 0 {
-        // Dismiss any partial state, then retry
+        // Dismiss any partial state, then retry once the picker is tappable again
+        // (the partial menu overlay blocks hittability until it clears).
         app.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.1)).tap()
-        sleep(1)
+        pickerButton.waitUntilHittable()
         pickerButton.forceTap()
       } else {
         pickerButton.forceTap()

--- a/FARTUITests/Pages/PilotProfilePage.swift
+++ b/FARTUITests/Pages/PilotProfilePage.swift
@@ -2,6 +2,9 @@ import XCTest
 
 class PilotProfilePage: BasePage {
 
+  var lowCeilingPicker: XCUIElement { app.buttons["lowCeilingPicker"] }
+  var lowVisibilityPicker: XCUIElement { app.buttons["lowVisibilityPicker"] }
+
   @discardableResult
   func selectVFR() -> Self {
     selectPickerOption(picker: "ratingPicker", option: "ratingVFR", optionLabel: "VFR")
@@ -23,10 +26,10 @@ class PilotProfilePage: BasePage {
   }
 
   func isLowCeilingPickerVisible() -> Bool {
-    app.buttons["lowCeilingPicker"].waitForExistence(timeout: 2)
+    lowCeilingPicker.waitForExistence(timeout: 2)
   }
 
   func isLowVisibilityPickerVisible() -> Bool {
-    app.buttons["lowVisibilityPicker"].waitForExistence(timeout: 2)
+    lowVisibilityPicker.waitForExistence(timeout: 2)
   }
 }

--- a/FARTUITests/Pages/Sections/WeatherSectionPage.swift
+++ b/FARTUITests/Pages/Sections/WeatherSectionPage.swift
@@ -2,6 +2,16 @@ import XCTest
 
 class WeatherSectionPage: BasePage {
 
+  // MARK: - Field Accessors
+
+  var vfrCeilingUnder3000Toggle: XCUIElement { app.switches["vfrCeilingUnder3000Toggle"] }
+  var vfrVisibilityUnder5Toggle: XCUIElement { app.switches["vfrVisibilityUnder5Toggle"] }
+  var vfrFlightPlanToggle: XCUIElement { app.switches["vfrFlightPlanToggle"] }
+  var vfrFlightFollowingToggle: XCUIElement { app.switches["vfrFlightFollowingToggle"] }
+  var ifrLowCeilingToggle: XCUIElement { app.switches["ifrLowCeilingToggle"] }
+  var ifrLowVisibilityToggle: XCUIElement { app.switches["ifrLowVisibilityToggle"] }
+  var ifrApproachTypePicker: XCUIElement { app.buttons["ifrApproachTypePicker"] }
+
   // MARK: - Flight Type
 
   @discardableResult

--- a/FARTUITests/Pages/TabBarPage.swift
+++ b/FARTUITests/Pages/TabBarPage.swift
@@ -1,4 +1,5 @@
 import XCTest
+import XCUITestKit
 
 class TabBarPage: BasePage {
   // swiftlint:disable:next type_contents_order
@@ -77,9 +78,10 @@ class TabBarPage: BasePage {
     // On iPad, stale picker menus from the Pilot Profile can block the tab switch.
     let firstToggle = app.switches["lessThan50InTypeToggle"]
     if !firstToggle.waitForExistence(timeout: 5) {
-      // Dismiss any open menus/popovers and retry
+      // Dismiss any open menus/popovers, wait for the Questions tab to become
+      // tappable again (the overlay blocks it), then retry.
       app.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.5)).tap()
-      sleep(1)
+      app.tabBars.buttons[Tab.questions.rawValue].waitUntilHittable()
       goTo(tab: .questions)
       _ = firstToggle.waitForExistence(timeout: 10)
     }

--- a/FARTUITests/Tests/PilotProfileTests.swift
+++ b/FARTUITests/Tests/PilotProfileTests.swift
@@ -1,4 +1,5 @@
 import XCTest
+import XCUITestKit
 
 // swiftlint:disable prefer_nimble
 final class PilotProfileTests: FARTUITestCase {
@@ -14,8 +15,8 @@ final class PilotProfileTests: FARTUITestCase {
 
     // Switch back to VFR — pickers should disappear
     profile.selectVFR()
-    XCTAssertFalse(app.buttons["lowCeilingPicker"].exists)
-    XCTAssertFalse(app.buttons["lowVisibilityPicker"].exists)
+    profile.lowCeilingPicker.assertHidden()
+    profile.lowVisibilityPicker.assertHidden()
 
     // Switch to IFR again — pickers should reappear
     profile.selectIFR()

--- a/FARTUITests/Tests/QuestionnaireTests.swift
+++ b/FARTUITests/Tests/QuestionnaireTests.swift
@@ -1,6 +1,6 @@
 import XCTest
+import XCUITestKit
 
-// swiftlint:disable prefer_nimble
 final class QuestionnaireTests: FARTUITestCase {
 
   @MainActor
@@ -10,44 +10,46 @@ final class QuestionnaireTests: FARTUITestCase {
     // VFR by default — scroll to last VFR weather toggle to ensure all are loaded
     _ = q.scrollTo("vfrFlightFollowingToggle")
 
+    let weather = q.weatherSection
+
     // VFR toggles visible
-    XCTAssertTrue(app.switches["vfrFlightFollowingToggle"].exists)
-    XCTAssertTrue(app.switches["vfrFlightPlanToggle"].exists)
-    XCTAssertTrue(app.switches["vfrVisibilityUnder5Toggle"].exists)
-    XCTAssertTrue(app.switches["vfrCeilingUnder3000Toggle"].exists)
+    weather.vfrFlightFollowingToggle.assertExists()
+    weather.vfrFlightPlanToggle.assertExists()
+    weather.vfrVisibilityUnder5Toggle.assertExists()
+    weather.vfrCeilingUnder3000Toggle.assertExists()
 
     // IFR toggles not present
-    XCTAssertFalse(app.switches["ifrLowCeilingToggle"].exists)
-    XCTAssertFalse(app.switches["ifrLowVisibilityToggle"].exists)
-    XCTAssertFalse(app.buttons["ifrApproachTypePicker"].exists)
+    weather.ifrLowCeilingToggle.assertNeverAppears()
+    weather.ifrLowVisibilityToggle.assertNeverAppears()
+    weather.ifrApproachTypePicker.assertNeverAppears()
 
     // Switch to IFR
-    q.weatherSection.selectIFR()
+    weather.selectIFR()
 
     // IFR toggles visible
-    XCTAssertTrue(app.switches["ifrLowCeilingToggle"].waitForExistence(timeout: 3))
-    XCTAssertTrue(app.switches["ifrLowVisibilityToggle"].exists)
-    XCTAssertTrue(app.buttons["ifrApproachTypePicker"].exists)
+    weather.ifrLowCeilingToggle.assertExists()
+    weather.ifrLowVisibilityToggle.assertExists()
+    weather.ifrApproachTypePicker.assertExists()
 
     // VFR toggles gone
-    XCTAssertFalse(app.switches["vfrCeilingUnder3000Toggle"].exists)
-    XCTAssertFalse(app.switches["vfrVisibilityUnder5Toggle"].exists)
-    XCTAssertFalse(app.switches["vfrFlightPlanToggle"].exists)
-    XCTAssertFalse(app.switches["vfrFlightFollowingToggle"].exists)
+    weather.vfrCeilingUnder3000Toggle.assertNeverAppears()
+    weather.vfrVisibilityUnder5Toggle.assertNeverAppears()
+    weather.vfrFlightPlanToggle.assertNeverAppears()
+    weather.vfrFlightFollowingToggle.assertNeverAppears()
 
     // Switch back to VFR
-    q.weatherSection.selectVFR()
+    weather.selectVFR()
 
     // VFR toggles back
-    XCTAssertTrue(app.switches["vfrCeilingUnder3000Toggle"].waitForExistence(timeout: 3))
-    XCTAssertTrue(app.switches["vfrVisibilityUnder5Toggle"].exists)
-    XCTAssertTrue(app.switches["vfrFlightPlanToggle"].exists)
-    XCTAssertTrue(app.switches["vfrFlightFollowingToggle"].exists)
+    weather.vfrCeilingUnder3000Toggle.assertExists()
+    weather.vfrVisibilityUnder5Toggle.assertExists()
+    weather.vfrFlightPlanToggle.assertExists()
+    weather.vfrFlightFollowingToggle.assertExists()
 
     // IFR toggles gone again
-    XCTAssertFalse(app.switches["ifrLowCeilingToggle"].exists)
-    XCTAssertFalse(app.switches["ifrLowVisibilityToggle"].exists)
-    XCTAssertFalse(app.buttons["ifrApproachTypePicker"].exists)
+    weather.ifrLowCeilingToggle.assertNeverAppears()
+    weather.ifrLowVisibilityToggle.assertNeverAppears()
+    weather.ifrApproachTypePicker.assertNeverAppears()
   }
 
   @MainActor
@@ -195,4 +197,3 @@ final class QuestionnaireTests: FARTUITestCase {
       .assertResults(score: "3", riskLevel: "LOW RISK")
   }
 }
-// swiftlint:enable prefer_nimble


### PR DESCRIPTION
Aligns `FARTUITests` with the new SwiftUI UI-testing guidance.

## Changes
- **Auto-waiting, never `sleep`:** replaced the two literal `sleep(1)` calls — the picker-retry loop in `BasePage.swift` and the stale-menu retry in `TabBarPage.swift` — with predicate-based waits consistent with the existing `waitForElement` (`waitForExistence`) helper.
- **Screen objects own element access:** folded the direct `XCUIApplication` existence checks in `QuestionnaireTests` and `PilotProfileTests` into page-object accessors so test bodies no longer reach into the app element tree.

## Verification (local)
- `xcodebuild build-for-testing` (scheme `FART (iOS)`, iPhone 17 simulator): **succeeded**
- `swiftlint --strict`: **clean**
- `xcodebuild test` for the two affected classes (`UI Tests` test plan, iPhone 17): **passed**

`.ruby-version` (an unrelated pre-existing local change) was deliberately left out of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)