### PR TITLE
Stop the iPad UI tests losing toggle presses

### DIFF
--- a/FARTUITests/Pages/BasePage.swift
+++ b/FARTUITests/Pages/BasePage.swift
@@ -36,13 +36,13 @@ class BasePage {
     if element.waitForExistence(timeout: 2) {
       let collectionView = app.collectionViews.firstMatch
       if let control = collectionView.makeVisible(element: element) {
-        toggleSwitch(control, to: value)
+        toggleSwitch(control, to: value, named: identifier)
         return self
       }
       // Element exists but makeVisible failed — scroll to top and retry
       scrollToTop()
       if let control = collectionView.makeVisible(element: element) {
-        toggleSwitch(control, to: value)
+        toggleSwitch(control, to: value, named: identifier)
         return self
       }
       XCTFail("Could not scroll to toggle: \(identifier)")
@@ -53,14 +53,14 @@ class BasePage {
     let collectionView = app.collectionViews.firstMatch
     if collectionView.exists {
       if let control = collectionView.makeVisible(element: element) {
-        toggleSwitch(control, to: value)
+        toggleSwitch(control, to: value, named: identifier)
         return self
       }
 
       // Try from the top
       scrollToTop()
       if let control = collectionView.makeVisible(element: element) {
-        toggleSwitch(control, to: value)
+        toggleSwitch(control, to: value, named: identifier)
         return self
       }
     }
@@ -186,8 +186,13 @@ class BasePage {
   }
 
   /// Toggle a switch to the desired state using the child switch control.
-  private func toggleSwitch(_ element: XCUIElement, to value: Bool) {
-    element.setSwitch(to: value, in: app)
+  ///
+  /// A switch that never flips would otherwise surface much later as a wrong score, naming
+  /// neither the toggle nor the step that lost it.
+  private func toggleSwitch(_ element: XCUIElement, to value: Bool, named identifier: String) {
+    if !element.setSwitch(to: value, in: app) {
+      XCTFail("Could not set toggle \(identifier) to \(value)")
+    }
   }
 
   /// Scrolls to an element in the collection view.

--- a/Flight Assessment of Risk Tool.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Flight Assessment of Risk Tool.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -34,7 +34,7 @@
       "location" : "https://github.com/RISCfuture/XCUITestKit",
       "state" : {
         "branch" : "main",
-        "revision" : "bf475142079b67c0773e3f1c89ba71dbf98b0275"
+        "revision" : "8339050df71c8d815d3122b07f189e785da1e503"
       }
     }
   ],


### PR DESCRIPTION
The iPad UI-test leg had been red on scores that were simply wrong — `testVFROver100LowRisk` expected 11 and got 9, 14, and 6 across its three retries — and the job was taking 2h25m. Investigation traced it to two defects in XCUITestKit, both now fixed upstream, plus one local change so the next occurrence names itself.

## What was wrong

A synthesized press on an iOS 26 SwiftUI toggle has to be held past a cliff between a tenth and a fifth of a second: 0.2s lands every time (25/25 measured), 0.1s lands 64% of the time. `setSwitch` opened at exactly 0.1s, so roughly a third of first presses were lost — and a lost press is not merely retried, it costs a full `ScaledTimeouts.short` (9s at this project's 3× multiplier) before the longer retry lands. That is ~12.2s per toggle instead of ~1.9s, and when all five attempts were lost the toggle was left silently in the wrong state.

`scrollIntoSafeBand` separately spent its whole gesture budget on nudges that could not move anything. The band is measured against the window, but the iPad sidebar form starts at y=32, so the first rows of every section sit below the band floor with the list already at its top and no drag brings them down — five futile drags per toggle, ~10.2s per call. That queued event synthesis is what pushes a *later* tap past the per-test execution time allowance.

Both are iPad-shaped because the questionnaire lives in a `NavigationSplitView` sidebar there; the iPhone leg has the same helpers but a layout that mostly stays inside the band.

## Changes here

- Take the two XCUITestKit fixes (`8339050`).
- `BasePage.toggleSwitch` was discarding `setSwitch`'s result, so a lost toggle surfaced only as a score mismatch several steps later, naming neither the toggle nor the step that lost it. It now fails with the identifier. The test outcome is unchanged — a switch left wrong fails the score assertion regardless — only the diagnosis improves.

## Verification

| | before | after |
|---|---|---|
| iPad suite | 2h24m56s, 19 failures | 27/27 green, 28m48s |
| iPhone suite | green | 27/27 green, no regression |

`swift-format lint --strict` and `swiftlint --strict` both clean.

## Known residual

One iPhone test hit 919s in an otherwise-normal run (127.7s on iPad). That is the random hang in XCUITest's pre-event quiescence wait already documented in XCUITestKit, not something introduced here — every other test tracked iPad times closely. It exceeds the 420s CI allowance, so it would be killed and retried by the rescue pass in `af6ef32`. Raising `test-execution-time-allowance` for the iPad matrix entry may be worth considering separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)